### PR TITLE
server: add one-shot mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665ff4dce8edd10d490641ccb78949832f1ddbff02c584fb1f85ab888fe0e50c"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +905,7 @@ dependencies = [
  "ed25519-dalek",
  "flate2",
  "hyper",
+ "ignore-result",
  "rand",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ ed25519 = { version = "2.2.2", features = ["alloc", "pkcs8"] }
 ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 flate2 = "1.0.28"
 hyper = { version = "0.14.27", features = ["http1", "server", "tcp"] }
+ignore-result = "0.2.0"
 rand = "0.8.5"
 reqwest = { version = "0.11.22", default-features = false, features = ["blocking"], optional = true }
 serde = "1.0.188"


### PR DESCRIPTION
Running with one-shot enabled causes the server to exit after serving a single request. This is useful for cases where the input isn't trusted and a new enclave needs to be created for each request.